### PR TITLE
authenticate workflow with github token

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -11,6 +11,8 @@ jobs:
     name: Check all sites
     steps:
       - uses: actions/checkout@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Shell Script
         id: shell_script_run
         run: bash ./health-check.sh


### PR DESCRIPTION
Default permissions for github workflows are set such that they should be able to bypass branch protection, but they're not being applied. 
Not sure how it was working before and why it suddenly started failing, but hopefully this fixes it.