### PR TITLE
Update mobile layout to be more friendly to taps

### DIFF
--- a/index.css
+++ b/index.css
@@ -164,7 +164,6 @@ footer a {
   border-radius: 3px;
   height: 30px;
   min-width: 8px;
-  max-width: 20px;
   width: 100%;
 }
 
@@ -344,7 +343,7 @@ footer a {
     width: 100%;
     max-width: calc(10% - 4.5px);
   }
-  
+
   .statusStreamContainer {
     flex-wrap: wrap;
     row-gap: 5px;

--- a/index.css
+++ b/index.css
@@ -164,6 +164,7 @@ footer a {
   border-radius: 3px;
   height: 30px;
   min-width: 8px;
+  max-width: 20px;
   width: 100%;
 }
 
@@ -335,11 +336,18 @@ footer a {
   }
 
   .statusSquare + .statusSquare {
-    margin-left: 1px;
+    margin-left: 0px;
   }
 
   .statusSquare {
     min-width: 4px;
     width: 100%;
+    max-width: calc(10% - 4.5px);
+  }
+  
+  .statusStreamContainer {
+    flex-wrap: wrap;
+    row-gap: 5px;
+    column-gap: 5px;
   }
 }

--- a/index.html
+++ b/index.html
@@ -1,7 +1,8 @@
-<html>
+<html lang="en">
   <head>
     <title>Statsig Status</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" property="description" content="Check the current Statsig health status and view past incidents." />
     <link rel="stylesheet" href="index.css" />
     <script src="index.js"></script>
     <script async src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>


### PR DESCRIPTION
Not sure if this is a sufficient increase in tap size, but makes it a good bit easier to tap these on mobile by splitting into 3 rows of 10

<img width="634" alt="Screen Shot 2022-11-07 at 11 25 03 AM" src="https://user-images.githubusercontent.com/77301670/200397012-51bfe0f5-5820-48d9-9b1e-1b83c53216e6.png">
<img width="1007" alt="Screen Shot 2022-11-07 at 11 28 46 AM" src="https://user-images.githubusercontent.com/77301670/200397631-cbaf60b1-efbb-4c12-b94a-9c6b125aeb2d.png">

Also add an SEO tag and language